### PR TITLE
Add a CMake file populating variables with files

### DIFF
--- a/.avogadrogenerators
+++ b/.avogadrogenerators
@@ -1,1 +1,0 @@
-File to identify base directory of Avogadro generators repository.

--- a/generators.cmake
+++ b/generators.cmake
@@ -1,0 +1,16 @@
+# List all generators that should be installed by default here.
+set(input_generators
+  apbs.py
+  dalton.py
+  gamessuk.py
+  gaussian.py
+  molpro.py
+  mopac.py
+  nwchem.py
+  orca.py
+  qchem.py
+  terachem.py
+  )
+
+# Optional test generator.
+set(test_generator inputgeneratortest.py)


### PR DESCRIPTION
This effectively migrates the listing of files from avogadrolibs to this
repository, any external CMake can then include this file and have a
full list of generators to install. Remove the unique hidden file, and
use this file as its replacement to confirm the correct project has
likely been found.

Signed-off-by: Marcus D. Hanwell <marcus.hanwell@kitware.com>