### PR TITLE
Make pytest and pyupgrade mandatory tests

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -20,7 +20,6 @@ jobs:
       - run: pip install -r requirements.txt || pip install --editable . || true
       - run: mkdir --parents --verbose .mypy_cache
       - run: mypy --ignore-missing-imports --install-types --non-interactive .
-      - run: pytest . || true
-      - run: pytest --doctest-modules . || true
+      - run: pytest --doctest-modules .
       - run: shopt -s globstar && pyupgrade --py36-plus **/*.py
       - run: safety check

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -22,5 +22,5 @@ jobs:
       - run: mypy --ignore-missing-imports --install-types --non-interactive .
       - run: pytest . || true
       - run: pytest --doctest-modules . || true
-      - run: shopt -s globstar && pyupgrade --py36-plus **/*.py || true
+      - run: shopt -s globstar && pyupgrade --py36-plus **/*.py
       - run: safety check

--- a/dalton.py
+++ b/dalton.py
@@ -30,6 +30,15 @@ symbols = [
 
 
 def getOptions():
+    """
+    >>> opts = getOptions()
+    >>> "userOptions" in opts
+    True
+    >>> "inputMoleculeFormat" in opts
+    True
+    >>> len(opts["userOptions"])
+    6
+    """
     userOptions = {}
 
     userOptions['Title'] = {}


### PR DESCRIPTION
Signed-off-by: Christian Clauss <cclauss@me.com>

Make `pyupgrade` from #11 a mandatory test in our GitHub Actions tests #12.

Also add some [doctests](https://docs.python.org/3/library/doctest.html) and make pytest mandatory.

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
