### PR TITLE
Excited states and symmetry settings in ORCA generator

### DIFF
--- a/orca.py
+++ b/orca.py
@@ -206,8 +206,30 @@ def getOptions():
         "type": "integer",
         "default": 200,
     }
+    excitOptions = {"tabName": "Excited States"}
+    excitOptions["Excited State Method"] = {
+        "type": "stringList",
+        "default": "None",
+        "values": [
+            "None",
+            "CIS",
+            "CIS(D)",
+            "TDDFT",
+            "EOM-CCSD",
+        ],
+    }
+    excitOptions["Number of States"] = {
+        "type": "integer",
+        "default": 3,
+        "minimum": 1,
+    }
+    excitOptions["Target State"] = {
+        "type": "integer",
+        "default": 1,
+        "minimum": 1,
+    }
 
-    opts = {"userOptions": [userOptions, aimdOptions]}
+    opts = {"userOptions": [userOptions, aimdOptions, excitOptions]}
     opts['inputMoleculeFormat'] = 'cjson'
 
     return opts
@@ -232,6 +254,9 @@ def generateInputFile(opts,cjson):
     disp = opts["Dispersion Correction"]
     ri = opts["RI Approximation"]
     auxbasis = "None"
+    excit = opts["Excited State Method"]
+    nroots = opts["Number of States"]
+    iroot = opts["Target State"]
 
     rijbasis = {
         "6-31G(d)": "AutoAux",
@@ -319,10 +344,18 @@ def generateInputFile(opts,cjson):
     if auxbasis != "None":
         basis = basis + " " + auxbasis
 
+    if auxbasis == "None" and excit == "CIS(D)":
+        basis = basis + " " + "AutoAux"
+
     if sym == True:
         usesymmetry = 'UseSym'
     else:
         usesymmetry = ''
+
+    if excit == 'EOM-CCSD':
+        theory="EOM-CCSD"
+    elif excit in ["CIS", "CIS(D)"]:
+        theory="HF"
 
     if "-3c" in theory or "-3C" in theory:
         # -3c composite methods have everything together
@@ -362,6 +395,20 @@ def generateInputFile(opts,cjson):
         )
         output += '   dump position stride 1 filename "trajectory.xyz"\n'
         output += "   run " + str(opts["AIMD RunTime"]) + "\n"
+        output += "end\n\n"
+
+    # Excited states
+    if excit == "CIS" or excit == "CIS(D)":
+        output += "%cis\n"
+    elif excit == "TDDFT":
+        output += "%tddft\n"
+    elif excit == "EOM-CCSD":
+        output += "%mdci\n"
+    if excit != "None":
+        output += f"   nroots {nroots}\n"
+        output += f"   iroot  {iroot}\n"
+        if excit == "CIS(D)":
+            output += "   dcorr 1\n"
         output += "end\n\n"
 
     if mos == True:


### PR DESCRIPTION
# Summary
Added settings to ORCA input:

- UseSym keyword with checkbox
- Excited state settigs (TDDFT, CIS, CIS(D) and EOM-CCSD) through a dedicated tab


# Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
