### PR TITLE
Add ORCA UseSym checkbox and explicit option order

### DIFF
--- a/scripts/write_orca_options.py
+++ b/scripts/write_orca_options.py
@@ -82,6 +82,7 @@ class BasicOption:
     label: str
     options: tuple | None = None
     toolTip: str | None = None
+    order: int | None = None
     hide: bool | None = None
     minimum: int | float | None = None
     maximum: int | float | None = None
@@ -242,6 +243,7 @@ class BasicTab:
             dtype="stringList",
             default=0,
             label="Dispersion Correction",
+            order=0,
             options=(
                 Disp.NODISP,
                 Disp.D3BJ,
@@ -255,11 +257,19 @@ class BasicTab:
             dtype="boolean",
             default=True,
             label="Print Molecular Orbitals",
+            order=1,
+        ),
+        "basic_constrain": BasicOption(
+            dtype="boolean",
+            default=False,
+            label="Use Constraints",
+            order=2,
         ),
         "basic_print_level": BasicOption(
             dtype="stringList",
             default=2,  # NormalPrint
             label="Print Level",
+            order=3,
             options=(
                 Output.MINIPRINT,
                 Output.SMALLPRINT,
@@ -267,16 +277,19 @@ class BasicTab:
                 Output.LARGEPRINT,
             ),
         ),
-        "basic_constrain": BasicOption(
+        "basic_use_symmetry": BasicOption(
             dtype="boolean",
             default=False,
-            label="Use Constraints",
+            label="Use Symmetry",
+            toolTip="Emit the UseSym simple keyword.",
+            order=4,
         ),
         "basic_simple_keywords": BasicOption(
             dtype="string",
             default="",
             label="Additional Simple Keywords",
             toolTip="Comma- or whitespace-separated list of simple input keywords.",
+            order=5,
         ),
     }
     # fmt: on
@@ -310,6 +323,9 @@ class BasicTab:
 
             if val.toolTip is not None:
                 tab += f'toolTip = "{val.toolTip}"\n'
+
+            if val.order is not None:
+                tab += f"order = {val.order}\n"
 
             tab += f'tab = "{cls.name}"\n\n'
 

--- a/src/avogadro_generators/orca/__init__.py
+++ b/src/avogadro_generators/orca/__init__.py
@@ -83,6 +83,7 @@ def generateInputFile(input_json: dict) -> tuple[str, list[str], list[str]]:
     solvent         = opts["Solvent"]
     disp            = opts["basic_disp_corr"]
     print_mos: bool = opts["basic_print_mos"]
+    use_symmetry: bool = opts["basic_use_symmetry"]
     print_level     = Output(opts["basic_print_level"])
     constrain: bool = opts["basic_constrain"]
 
@@ -166,6 +167,9 @@ def generateInputFile(input_json: dict) -> tuple[str, list[str], list[str]]:
 
     if print_mos:
         simple_keywords.extend([Output.PRINTMOS, Output.PRINTBASIS])
+
+    if use_symmetry:
+        simple_keywords.append("UseSym")
 
     if print_level != "NormalPrint":
         simple_keywords.append(print_level)

--- a/src/avogadro_generators/orca/options.toml
+++ b/src/avogadro_generators/orca/options.toml
@@ -170,12 +170,21 @@ values = [
     "NL",
     "SCNL",
 ]
+order = 0
 tab = "Basic"
 
 ["basic_print_mos"]
 label = "Print Molecular Orbitals"
 type = "boolean"
 default = true
+order = 1
+tab = "Basic"
+
+["basic_constrain"]
+label = "Use Constraints"
+type = "boolean"
+default = false
+order = 2
 tab = "Basic"
 
 ["basic_print_level"]
@@ -188,12 +197,15 @@ values = [
     "NormalPrint",
     "LargePrint",
 ]
+order = 3
 tab = "Basic"
 
-["basic_constrain"]
-label = "Use Constraints"
+["basic_use_symmetry"]
+label = "Use Symmetry"
 type = "boolean"
 default = false
+toolTip = "Add UseSym keyword."
+order = 4
 tab = "Basic"
 
 ["basic_simple_keywords"]
@@ -201,6 +213,7 @@ label = "Additional Simple Keywords"
 type = "string"
 default = ""
 toolTip = "Comma- or whitespace-separated list of simple input keywords."
+order = 5
 tab = "Basic"
 
 [Basis_pople]
@@ -538,56 +551,56 @@ tab = "SCF"
 [SCF_TOL_E]
 label = "Energy Tolerance"
 type = "string"
-default = 1e-08
+default = 1e-06
 toolTip = "Set the SCF energy convergence criteria."
 tab = "SCF"
 
 [SCF_TOL_RMSP]
 label = "RMS Density Tolerance"
 type = "string"
-default = 5e-09
+default = 1e-06
 toolTip = "Set the SCF RMS density change convergence criteria."
 tab = "SCF"
 
 [SCF_TOL_MAXP]
 label = "Max Density Tolerance"
 type = "string"
-default = 1e-07
+default = 1e-05
 toolTip = "Set the SCF maximum density change convergence criteria."
 tab = "SCF"
 
 [SCF_TOL_ERR]
 label = "DIIS Error Tolerance"
 type = "string"
-default = 5e-07
+default = 1e-05
 toolTip = "Set the SCF DIIS Error convergence criteria."
 tab = "SCF"
 
 [SCF_TOL_G]
 label = "Orbital Gradient Tolerance"
 type = "string"
-default = 1e-05
+default = 5e-05
 toolTip = "Set the SCF orbital gradient convergence criteria."
 tab = "SCF"
 
 [SCF_TOL_X]
 label = "Orbital Rotation Angle Tolerance"
 type = "string"
-default = 1e-05
+default = 5e-05
 toolTip = "Set the SCF orbital rotation angle convergence criteria."
 tab = "SCF"
 
 [SCF_THRESH]
 label = "Integral Prescreening Threshold"
 type = "string"
-default = 2.5e-11
+default = 1e-10
 toolTip = "Set the SCF integral prescreening threshold."
 tab = "SCF"
 
 [SCF_TCUT]
 label = "Primitive Integral Prescreening Cutoff"
 type = "string"
-default = 2.5e-12
+default = 1e-11
 toolTip = "Set the SCF primitive integral prescreening threshold."
 tab = "SCF"
 

--- a/src/avogadro_generators/orca/simple_keywords.py
+++ b/src/avogadro_generators/orca/simple_keywords.py
@@ -93,6 +93,12 @@ class Output(StrEnum):
     KEEPTRANSDENSITY = "KeepTransDensity"
 
 
+class Symmetry(StrEnum):
+    """Control of symmetry handling."""
+
+    USESYM = "UseSym"
+
+
 class Grid(StrEnum):
     """Control of Numerical Integration Grids."""
 
@@ -157,6 +163,7 @@ def match_simple_keyword(kwd: str):
         DeterminantType,
         Opt,
         Output,
+        Symmetry,
         Grid,
         RIApproximation,
         PartialCharges,

--- a/src/avogadro_generators/orca/syntax.toml
+++ b/src/avogadro_generators/orca/syntax.toml
@@ -67,6 +67,7 @@ patterns = [
     { regexp = '\b(UNO)\s',              caseSensitive = false},
     { regexp = '\b(NoPropFile)\s',       caseSensitive = false},
     { regexp = '\b(KeepTransDensity)\s', caseSensitive = false},
+    { regexp = '\b(UseSym)\s',           caseSensitive = false},
     { regexp = '\b(COSJXC)\s',           caseSensitive = false},
     { regexp = '\b(NoCOSX)\s',           caseSensitive = false},
     { regexp = '\b(NoRI)\s',             caseSensitive = false},


### PR DESCRIPTION
Added UseSym keyword to accepted simple keywords and added
and a checkbox to add it to the input

NOTE: the order keyword in the options.toml has been added for
basic tab in order to ensure that the checkbox does not fall to the
bottom of the tab

Developer Certificate of Origin
Version 1.1

Copyright (C) 2004, 2006 The Linux Foundation and its contributors.
1 Letterman Drive
Suite D4700
San Francisco, CA, 94129

Everyone is permitted to copy and distribute verbatim copies of this
license document, but changing it is not allowed.


Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
